### PR TITLE
Adding 2 new vendors

### DIFF
--- a/billing_vendors/vendors.json
+++ b/billing_vendors/vendors.json
@@ -35,6 +35,15 @@
         {
         "name": "Stripe",
         "url": "https://stripe.com/docs/billing/subscriptions/usage-based"
+      },
+        {
+        "name": "Metronome",
+        "url": "https://metronome.com/"
+      },
+        {
+        "name": "Octane",
+        "url": "https://www.getoctane.io/"
       }
+        
     ]
   }


### PR DESCRIPTION
Adding 2 new vendors that support usage based billing i.e. Metronome, and Octane.